### PR TITLE
Initial implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- …
+- Initial implementation ([#1])
 
-[Unreleased]: https://github.com/appuio/component-openshift-prometheus-proxy/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/appuio/component-openshift-prometheus-proxy/compare/feb66d43c1cc1c6e2031db9f04ea11fd7bd346a0...HEAD
+[#1]: https://github.com/appuio/component-openshift-prometheus-proxy/pull/1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Commodore Component: openshift-prometheus-proxy
+# Commodore Component: OpenShift Prometheus Proxy
 
-This is a [Commodore][commodore] Component for openshift-prometheus-proxy.
+This is a [Commodore][commodore] Component for [openshift-prometheus-proxy][https://github.com/appuio/openshift-prometheus-proxy].
 
 This repository is part of Project Syn.
 For documentation on Project Syn and this component, see https://syn.tools.

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,3 +7,4 @@ parameters:
       OPENSHIFT_PROMETHEUS_PROXY_HOSTNAME: openshift-prometheus-proxy.example.com
       OPENSHIFT_PROMETHEUS_PROXY_SESSION_SECRET: ?{vaultkv:${customer:name}/${cluster:name}/openshift-prometheus-proxy/session-secret}
     route_enabled: false
+    version: 1ed15714a0039221e6067ea6e218593f08c1d8b1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,3 +1,9 @@
 parameters:
   openshift_prometheus_proxy:
     namespace: syn-openshift-prometheus-proxy
+    template_parameters:
+      OPENSHIFT_PROMETHEUS_PROXY_UPSTREAM: https://prometheus-k8s.openshift-monitoring.svc:9091
+      OPENSHIFT_PROMETHEUS_PROXY_TLS_VERIFY: "service"
+      OPENSHIFT_PROMETHEUS_PROXY_HOSTNAME: openshift-prometheus-proxy.example.com
+      OPENSHIFT_PROMETHEUS_PROXY_SESSION_SECRET: ?{vaultkv:${customer:name}/${cluster:name}/openshift-prometheus-proxy/session-secret}
+    route_enabled: false

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,6 @@
 parameters:
   openshift_prometheus_proxy:
-    namespace: syn-openshift-prometheus-proxy
+    namespace: appuio-prometheus-proxy
     template_parameters:
       OPENSHIFT_PROMETHEUS_PROXY_UPSTREAM: https://prometheus-k8s.openshift-monitoring.svc:9091
       OPENSHIFT_PROMETHEUS_PROXY_TLS_VERIFY: "service"

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,4 +7,4 @@ parameters:
       OPENSHIFT_PROMETHEUS_PROXY_HOSTNAME: openshift-prometheus-proxy.example.com
       OPENSHIFT_PROMETHEUS_PROXY_SESSION_SECRET: ?{vaultkv:${customer:name}/${cluster:name}/openshift-prometheus-proxy/session-secret}
     route_enabled: false
-    version: 1ed15714a0039221e6067ea6e218593f08c1d8b1
+    version: 6d95911207863fa3a5b8500720fc1c92e19ed445

--- a/class/openshift-prometheus-proxy.yml
+++ b/class/openshift-prometheus-proxy.yml
@@ -1,5 +1,9 @@
 parameters:
   kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/openshift-prometheus-proxy/master/template/openshift-prometheus-proxy.yaml
+        output_path: dependencies/openshift-prometheus-proxy/manifests/template.yaml
     compile:
       - input_paths:
           - openshift-prometheus-proxy/component/app.jsonnet

--- a/class/openshift-prometheus-proxy.yml
+++ b/class/openshift-prometheus-proxy.yml
@@ -2,8 +2,8 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/appuio/openshift-prometheus-proxy/master/template/openshift-prometheus-proxy.yaml
-        output_path: dependencies/openshift-prometheus-proxy/manifests/template.yaml
+        source: https://raw.githubusercontent.com/appuio/openshift-prometheus-proxy/${openshift_prometheus_proxy:version}/template/openshift-prometheus-proxy.yaml
+        output_path: dependencies/openshift-prometheus-proxy/manifests/${openshift_prometheus_proxy:version}/template.yaml
     compile:
       - input_paths:
           - openshift-prometheus-proxy/component/app.jsonnet

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -3,7 +3,41 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift_prometheus_proxy;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('openshift-prometheus-proxy', params.namespace);
+local app =
+  argocd.App('openshift-prometheus-proxy', params.namespace) {
+    spec+: {
+      ignoreDifferences+: [
+        {
+          group: 'image.openshift.io',
+          kind: 'ImageStream',
+          jsonPointers: [
+            // tags[].spec.importPolicy.schedule=false gets dropped by OCP3.11
+            '/spec/tags/0/importPolicy',
+            // tags[].spec.annotations=null gets set by OCP3.11
+            '/spec/tags/0/annotations',
+          ],
+        },
+        {
+          group: 'apps',
+          kind: 'Deployment',
+          jsonPointers: [
+            // container image field gets overwritten by imagestream
+            '/spec/template/spec/containers/0/image',
+            '/spec/template/spec/containers/1/image',
+          ],
+        },
+        {
+          group: 'build.openshift.io',
+          kind: 'BuildConfig',
+          jsonPointers: [
+            // ignore changes to spec.triggers elements
+            '/spec/triggers/0',
+            '/spec/triggers/1',
+          ],
+        },
+      ],
+    },
+  };
 
 {
   'openshift-prometheus-proxy': app,

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -15,7 +15,13 @@ local openshift_templates =
     'openshift-prometheus-proxy/manifests/template.yaml'
   ));
 
+local routeFilter(rendered) =
+  std.filter(
+    function(it) !(it.kind == 'Route' && !params.route_enabled),
+    rendered
+  );
+
 {
-  [t.template_name]: t.rendered_template
+  [t.template_name]: routeFilter(t.rendered_template)
   for t in [ (r { template:: t }) for t in openshift_templates ]
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -9,5 +9,6 @@ local namespace = kube.Namespace(params.namespace);
 
 {
   '00_namespace': namespace,
+  proxy_rbac: template.rbac,
 }
 + template.manifests

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,10 +1,21 @@
-// main template for openshift-prometheus-proxy
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local renderer = import 'openshift_template_renderer.libsonnet';
+
 local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift_prometheus_proxy;
 
-// Define outputs below
+local r = renderer.OpenShiftTemplateRenderer {
+  template_parameters:: params.template_parameters,
+};
+
+local openshift_templates =
+  std.parseJson(kap.yaml_load_stream(
+    'openshift-prometheus-proxy/manifests/template.yaml'
+  ));
+
 {
+  [t.template_name]: t.rendered_template
+  for t in [ (r { template:: t }) for t in openshift_templates ]
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,40 +1,13 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
-local renderer = import 'openshift_template_renderer.libsonnet';
+local template = import 'template.jsonnet';
 
 local inv = kap.inventory();
-// The hiera parameters for the component
 local params = inv.parameters.openshift_prometheus_proxy;
 
-local r = renderer.OpenShiftTemplateRenderer {
-  template_parameters:: params.template_parameters,
-};
+local namespace = kube.Namespace(params.namespace);
 
-// Note: the current implementation supports rendering all OpenShift
-// templates defined in the loaded YAML file.
-local openshift_templates =
-  std.parseJson(kap.yaml_load_stream(
-    'openshift-prometheus-proxy/manifests/%s/template.yaml' % params.version
-  ));
-
-local rendered = [ (r { template:: t }) for t in openshift_templates ];
-
-local output_name(t, kind) =
-  if std.length(rendered) > 1 then
-    '%s_%s' % [ t.template_name, kind ]
-  else
-    kind;
-
-// Merge output objects if input template file had multiple templates
-std.foldl(
-  function(a, it) a + it,
-  [
-    // Generate outputs from rendered template
-    {
-      [if !(kind == 'routes' && !params.route_enabled) then output_name(t, kind)]: t.rendered_kinds[kind]
-      for kind in std.objectFields(t.rendered_kinds)
-    }
-    for t in rendered
-  ],
-  {}
-)
+{
+  '00_namespace': namespace,
+}
++ template.manifests

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -14,7 +14,7 @@ local r = renderer.OpenShiftTemplateRenderer {
 // templates defined in the loaded YAML file.
 local openshift_templates =
   std.parseJson(kap.yaml_load_stream(
-    'openshift-prometheus-proxy/manifests/template.yaml'
+    'openshift-prometheus-proxy/manifests/%s/template.yaml' % params.version
   ));
 
 local rendered = [ (r { template:: t }) for t in openshift_templates ];

--- a/component/openshift_template_renderer.libsonnet
+++ b/component/openshift_template_renderer.libsonnet
@@ -50,6 +50,7 @@
         for k in std.objectFields(o)
       },
 
+
     // Read this variable to extract the rendered template objects as a list
     rendered_template:
       if std.assertEqual(self.template.kind, 'Template') then
@@ -59,5 +60,21 @@
     template_name:
       if std.assertEqual(self.template.kind, 'Template') then
         self.template.metadata.name,
+
+    // Read this variable to get an object with arrays of rendered manifests
+    // for each object kind present in the template
+    rendered_kinds:
+      local kind(it) =
+        if std.assertEqual(std.objectHas(it, 'kind'), true) then
+          std.asciiLower(it.kind) + 's';
+
+      local r = self;
+      local elems = [
+        {
+          [kind(it)]+: [ it ],
+        }
+        for it in r.rendered_template
+      ];
+      std.foldl(function(a, it) a + it, elems, {}),
   },
 }

--- a/component/openshift_template_renderer.libsonnet
+++ b/component/openshift_template_renderer.libsonnet
@@ -1,0 +1,63 @@
+// OpenShift template renderer
+{
+  OpenShiftTemplateRenderer:: {
+    template_parameters:: error 'Must provide template parameters as object with parameter name as key',
+
+    template:: error 'Must provide list of template objects',
+
+    param_required(it)::
+      std.objectHas(self.template_parameters, it.name) ||
+      (std.objectHas(it, 'required') && it.required) ||
+      // we cannot sanely handle generating values at compile time, so we require
+      // "generate" parameters to be present in the template parameters provided
+      // to the renderer.
+      std.objectHas(it, 'generate'),
+
+    tplparams::
+      local r = self;
+      {
+        [it.name]:
+          if r.param_required(it) then r.template_parameters[it.name]
+          else if std.objectHas(it, 'value') then it.value
+          else error 'unknown template parameter: %s' % it
+        for it in self.template.parameters
+      },
+
+    paramfuns:: [
+      function(it) std.strReplace(it, '${%s}' % param, self.tplparams[param])
+      for param in std.objectFields(self.tplparams)
+    ],
+
+    render_params(v):: std.foldl(function(it, f) f(it), self.paramfuns, v),
+
+    render_tpl_list(l)::
+      [
+        if std.isObject(it) then self.render_tpl_obj(it)
+        else if std.isArray(it) then self.render_tpl_list(it)
+        else if std.isString(it) then self.render_params(it)
+        else it
+        for it in l
+      ],
+
+    render_tpl_obj(o)::
+      local r = self;
+      {
+        [k]:
+          if std.isObject(o[k]) then r.render_tpl_obj(o[k])
+          else if std.isArray(o[k]) then r.render_tpl_list(o[k])
+          else if std.isString(o[k]) then r.render_params(o[k])
+          else o[k]
+        for k in std.objectFields(o)
+      },
+
+    // Read this variable to extract the rendered template objects as a list
+    rendered_template:
+      if std.assertEqual(self.template.kind, 'Template') then
+        [ self.render_tpl_obj(o) for o in self.template.objects ],
+
+    // Read this variable to extract the name of the template object
+    template_name:
+      if std.assertEqual(self.template.kind, 'Template') then
+        self.template.metadata.name,
+  },
+}

--- a/component/template.jsonnet
+++ b/component/template.jsonnet
@@ -1,0 +1,41 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local renderer = import 'openshift_template_renderer.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift_prometheus_proxy;
+
+local r = renderer.OpenShiftTemplateRenderer {
+  template_parameters:: params.template_parameters,
+};
+
+// Note: the current implementation supports rendering all OpenShift
+// templates defined in the loaded YAML file.
+local openshift_templates =
+  std.parseJson(kap.yaml_load_stream(
+    'openshift-prometheus-proxy/manifests/%s/template.yaml' % params.version
+  ));
+
+local rendered = [ (r { template:: t }) for t in openshift_templates ];
+
+local output_name(t, kind) =
+  if std.length(rendered) > 1 then
+    '%s_%s' % [ t.template_name, kind ]
+  else
+    kind;
+
+{
+  manifests:
+    // Merge output objects if input template file had multiple templates
+    std.foldl(
+      function(a, it) a + it,
+      [
+        // Generate outputs from rendered template
+        {
+          [if !(kind == 'routes' && !params.route_enabled) then output_name(t, kind)]: t.rendered_kinds[kind]
+          for kind in std.objectFields(t.rendered_kinds)
+        }
+        for t in rendered
+      ],
+      {}
+    ),
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -6,7 +6,7 @@ The parent key for all of the following parameters is `openshift_prometheus_prox
 
 [horizontal]
 type:: string
-default:: `syn-openshift-prometheus-proxy`
+default:: `appuio-prometheus-proxy`
 
 The namespace in which to deploy this component.
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -34,6 +34,14 @@ default:: `false`
 
 Whether to generate an OpenShift route object for the proxy.
 
+== `version`
+
+[horizontal]
+type:: boolean
+default:: https://github.com/appuio/openshift-prometheus-proxy/tree/1ed15714a0039221e6067ea6e218593f08c1d8b1[`1ed15714a0039221e6067ea6e218593f08c1d8b1`]
+
+This parameter specifies which version of the upstream repository (as a Git tree-ish) to use when rendering the component.
+
 == Example
 
 [source,yaml]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,10 +10,37 @@ default:: `syn-openshift-prometheus-proxy`
 
 The namespace in which to deploy this component.
 
+== `template_parameters`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+OPENSHIFT_PROMETHEUS_PROXY_UPSTREAM: https://prometheus-k8s.openshift-monitoring.svc:9091
+OPENSHIFT_PROMETHEUS_PROXY_TLS_VERIFY: "service"
+OPENSHIFT_PROMETHEUS_PROXY_HOSTNAME: openshift-prometheus-proxy.example.com
+OPENSHIFT_PROMETHEUS_PROXY_SESSION_SECRET: ?{vaultkv:${customer:name}/${cluster:name}/openshift-prometheus-proxy/session-secret}
+----
+
+Parameters used to render the OpenShift template provided as part of https://github.com/appuio/openshift-prometheus-proxy[OpenShift Prometheus Proxy]
+
+== `route_enabled`
+
+[horizontal]
+type:: boolean
+default:: `false`
+
+Whether to generate an OpenShift route object for the proxy.
 
 == Example
 
 [source,yaml]
 ----
-namespace: example-namespace
+openshift_prometheus_proxy:
+  namespace: example-namespace
+  template_parameters:
+    OPENSHIFT_PROMETHEUS_PROXY_HOSTNAME: my-awesome-prometheus-proxy.example.org
+  route_enabled: true
 ----


### PR DESCRIPTION
Commodore component for https://github.com/appuio/openshift-prometheus-proxy

The component generates the component manifests from the OpenShift template provided by upstream.

The OpenShift template rendering is implemented in Jsonnet, in `component/openshift_template_renderer.libsonnet`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
