### PR TITLE
Manage NetworkPolicy/NetNS and client RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial implementation ([#1])
+- Manage NetworkPolicy/NetNS and client RBAC ([#2])
 
 [Unreleased]: https://github.com/appuio/component-openshift-prometheus-proxy/compare/feb66d43c1cc1c6e2031db9f04ea11fd7bd346a0...HEAD
 [#1]: https://github.com/appuio/component-openshift-prometheus-proxy/pull/1
+[#2]: https://github.com/appuio/component-openshift-prometheus-proxy/pull/2

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -8,3 +8,6 @@ parameters:
       OPENSHIFT_PROMETHEUS_PROXY_SESSION_SECRET: ?{vaultkv:${customer:name}/${cluster:name}/openshift-prometheus-proxy/session-secret}
     route_enabled: false
     version: 6d95911207863fa3a5b8500720fc1c92e19ed445
+    access:
+      use_networkpolicy: true
+      service_accounts: []

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,4 +10,4 @@ parameters:
     version: 6d95911207863fa3a5b8500720fc1c92e19ed445
     access:
       use_networkpolicy: true
-      service_accounts: []
+      service_account_refs: []

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -58,7 +58,7 @@ local user_access =
         namespace: s.namespace,
         name: s.name,
       }
-      for s in params.access.service_accounts
+      for s in params.access.service_account_refs
     ],
   };
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -7,8 +7,66 @@ local params = inv.parameters.openshift_prometheus_proxy;
 
 local namespace = kube.Namespace(params.namespace);
 
+local networkpolicy =
+  kube.NetworkPolicy('allow-from-labelled-ns') {
+    spec+: {
+      ingress: [
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  'appuio.ch/prometheus-proxy': 'allowed',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+local netns =
+  kube._Object(
+    'network.openshift.io/v1',
+    'NetNamespace',
+    params.namespace
+  ) {
+    netid: 0,
+    netname: params.namespace,
+  };
+
+local network_access =
+  if params.access.use_networkpolicy then
+    networkpolicy
+  else
+    netns;
+
+local user_access =
+  kube.RoleBinding('proxy-access') {
+    metadata+: {
+      namespace: params.namespace,
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Role',
+      name: 'access-openshift-prometheus-proxy',
+    },
+    subjects: [
+      {
+        kind: 'ServiceAccount',
+        namespace: s.namespace,
+        name: s.name,
+      }
+      for s in params.access.service_accounts
+    ],
+  };
+
+
 {
   '00_namespace': namespace,
+  network_access: network_access,
+  user_access: user_access,
   proxy_rbac: template.rbac,
 }
 + template.manifests

--- a/docs/modules/ROOT/pages/how-tos/grant-access.adoc
+++ b/docs/modules/ROOT/pages/how-tos/grant-access.adoc
@@ -19,7 +19,7 @@ On such a cluster, even though the proxy service is accessible from all namespac
 
 By default, clients cannot access Prometheus through the proxy, as the proxy checks whether client tokens have been granted access.
 
-Client service accounts are granted access to the proxy by the component if they're listed in `parameters.openshift_prometheus_proxy.access.service_accounts`:
+Client service accounts are granted access to the proxy by the component if they're listed in `parameters.openshift_prometheus_proxy.access.service_account_refs`:
 
 .c-cluster-1234.yaml
 [source,yaml]
@@ -27,7 +27,7 @@ Client service accounts are granted access to the proxy by the component if they
 parameters:
   openshift_prometheus_proxy:
     access:
-      service_accounts:
+      service_account_refs:
         - namespace: cust-monitoring
           name: prometheus
 ----

--- a/docs/modules/ROOT/pages/how-tos/grant-access.adoc
+++ b/docs/modules/ROOT/pages/how-tos/grant-access.adoc
@@ -1,0 +1,33 @@
+= Grant a client access to the proxy
+
+== Service access restrictions
+
+The proxy is exposed inside the cluster as an OpenShift service (secured with a service-CA signed certificate).
+
+By default, the component deploys a `NetworkPolicy` which allows traffic from namespaces labelled with `appuio.ch/prometheus-proxy=allowed`.
+Enable access by executing
+
+[source,shell]
+----
+kubectl label ns cust-monitoring appuio.ch/prometheus-proxy=allowed --overwrite
+----
+
+If `parameters.openshift_prometheus_proxy.access.use_networkpolicy` is set to `false` (this is required for clusters which use the multitenant network plugin), the component instead configures the proxy namespace's network ID to 0.
+On such a cluster, even though the proxy service is accessible from all namespaces, only service accounts which are <<_rbac_rules_for_client_service_accounts,explicitly granted access>> can retrieve Prometheus metrics through the proxy.
+
+== RBAC rules for client service accounts
+
+By default, clients cannot access Prometheus through the proxy, as the proxy checks whether client tokens have been granted access.
+
+Client service accounts are granted access to the proxy by the component if they're listed in `parameters.openshift_prometheus_proxy.access.service_accounts`:
+
+.c-cluster-1234.yaml
+[source,yaml]
+----
+parameters:
+  openshift_prometheus_proxy:
+    access:
+      service_accounts:
+        - namespace: cust-monitoring
+          name: prometheus
+----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -42,6 +42,40 @@ default:: https://github.com/appuio/openshift-prometheus-proxy/tree/1ed15714a003
 
 This parameter specifies which version of the upstream repository (as a Git tree-ish) to use when rendering the component.
 
+== `access`
+
+Configure client access to the proxy.
+See xref:how-tos/grant-access.adoc[Grant a client access to the proxy] for a more detailed guide on access configuration.
+
+=== `access.use_networkpolicy`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+If this parameter is `true`, configure network access to the proxy namespace with a network policy.
+That network policy allows access to the proxy namespace from all namespaces labelled with `appuio.ch/prometheus-proxy=allowed`.
+
+If this parameter is `false`, configure network access to the proxy namespace by setting its network ID to 0.
+This option is provided to support OpenShift 3.11 clusters which use the multitenant network plugin.
+
+
+=== `access.service_accounts`
+
+[horizontal]
+type:: array
+default:: `[]`
+
+The contents of this array are used to create RBAC rules to allow client service accounts access to the Prometheus proxy.
+
+The format of each array entry must be
+
+[source,yaml]
+----
+namespace: cust-namespace
+name: service-account-name
+----
+
 == Example
 
 [source,yaml]
@@ -51,4 +85,8 @@ openshift_prometheus_proxy:
   template_parameters:
     OPENSHIFT_PROMETHEUS_PROXY_HOSTNAME: my-awesome-prometheus-proxy.example.org
   route_enabled: true
+  access:
+    service_accounts:
+      - namespace: cust-monitoring
+        name: prometheus
 ----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -60,7 +60,7 @@ If this parameter is `false`, configure network access to the proxy namespace by
 This option is provided to support OpenShift 3.11 clusters which use the multitenant network plugin.
 
 
-=== `access.service_accounts`
+=== `access.service_account_refs`
 
 [horizontal]
 type:: array
@@ -86,7 +86,7 @@ openshift_prometheus_proxy:
     OPENSHIFT_PROMETHEUS_PROXY_HOSTNAME: my-awesome-prometheus-proxy.example.org
   route_enabled: true
   access:
-    service_accounts:
+    service_account_refs:
       - namespace: cust-monitoring
         name: prometheus
 ----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,2 +1,7 @@
 * xref:index.adoc[Home]
+
+.References
 * xref:references/parameters.adoc[Parameters]
+
+.How-Tos
+* xref:how-tos/grant-access.adoc[Grant a client access to the proxy]


### PR DESCRIPTION
* Configure networkpolicy to allow namespaces labelled   with `appuio.ch/prometheus-proxy=allowed` to access the proxy service. If `use_networkpolicy` is false, configure the proxy's netnamespace to have network id 0 instead.
* Configure RBAC rules to allow serviceaccounts listed in `access.service_accounts` (name/namespace pairs) to access the proxy.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
