### PR TITLE
Only create RoleBinding for proxy clients if subjects is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation ([#1])
 - Manage NetworkPolicy/NetNS and client RBAC ([#2])
+- Only create RoleBinding for proxy client if subjects is not empty ([#4])
 
 [Unreleased]: https://github.com/appuio/component-openshift-prometheus-proxy/compare/feb66d43c1cc1c6e2031db9f04ea11fd7bd346a0...HEAD
 [#1]: https://github.com/appuio/component-openshift-prometheus-proxy/pull/1
 [#2]: https://github.com/appuio/component-openshift-prometheus-proxy/pull/2
+[#4]: https://github.com/appuio/component-openshift-prometheus-proxy/pull/4

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -66,7 +66,7 @@ local user_access =
 {
   '00_namespace': namespace,
   network_access: network_access,
-  user_access: user_access,
+  [if std.length(params.access.service_account_refs) > 0 then 'user_access']: user_access,
   proxy_rbac: template.rbac,
 }
 + template.manifests


### PR DESCRIPTION
This commit changes the component to only create the RoleBinding for proxy clients when the list of subjects (`access.service_account_refs`) for the RoleBinding is not empty.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
